### PR TITLE
Fix function signature matching in has_matching_nodes macro; update c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This file contains the changelog for the Data Engineers Snowflake DataOps Utils 
 ## v1.0.1 - 2026-05-10 - Function Signature Matching Fix
 
 ### Fixed
-- Fixed `has_matching_nodes` macro: Snowflake `information_schema.functions` returns type-only signatures (e.g. `(VARCHAR)`) but dbt parameters include names and DEFAULT clauses (e.g. `target_timezone STRING DEFAULT 'Pacific/Auckland'`). Added types-only fallback comparison that strips parameter names and DEFAULT clauses before matching. This prevents UDTFs/functions with DEFAULT parameters from being incorrectly dropped as orphans.
-- Fixed `has_matching_nodes` macro: multi-line parameters (from YAML block scalars or SQL config strings with newlines/tabs) now correctly normalised -- newlines and tabs are replaced with spaces then collapsed, so signature comparison succeeds regardless of whitespace formatting in the parameter definition.
-- Fixed `clean_functions` macro: fallback argument extraction failed on type-only Snowflake signatures because `argument.split(' ')[1]` is out of bounds when the argument is a single type word like `varchar`. Now correctly handles both `name type` and type-only formats, with whitespace-safe splitting.
+- Fixed `has_matching_nodes` macro: Snowflake `information_schema.functions` returns type-only signatures (e.g. `(VARCHAR)`) but dbt parameters include names and DEFAULT clauses (e.g. `target_timezone STRING DEFAULT 'Pacific/Auckland'`). Added type-only fallback comparison that strips parameter names and DEFAULT clauses before matching. This prevents UDTFs/functions with DEFAULT parameters from being incorrectly dropped as orphans.
+- Fixed `has_matching_nodes` macro: multi-line parameters (from YAML block scalars or SQL config strings with newlines/tabs) now correctly normalised via `collapse_whitespace` helper -- newlines and tabs are replaced with spaces then iteratively collapsed, handling arbitrarily long runs of whitespace.
+- Fixed `has_matching_nodes` and `clean_functions` macros: type extraction now uses `extract_param_type` helper which collects all tokens between the parameter name and `DEFAULT` keyword, correctly handling compound types with parenthesised precision like `NUMBER(15, 2)` or `VARCHAR(100)`.
+- Fixed `clean_functions` macro: fallback argument extraction failed on type-only Snowflake signatures because `argument.split(' ')[1]` is out of bounds when the argument is a single type word like `varchar`. Now uses shared helper macros for consistent handling.
+- Added `collapse_whitespace`, `split_params`, and `extract_param_type` helper macros in `macros/clean/_helpers.sql` to share whitespace normalisation, parenthesis-aware parameter splitting, and type extraction logic between `has_matching_nodes` and `clean_functions`.
 
 ### Changed
 - Bumped version from 1.0.0 to 1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Data Engineers Snowflake DataOps Utils Project Changelog
 This file contains the changelog for the Data Engineers Snowflake DataOps Utils project, detailing updates, fixes, and enhancements made to the project over time.
 
+## v1.0.1 - 2026-05-10 - Function Signature Matching Fix
+
+### Fixed
+- Fixed `has_matching_nodes` macro: Snowflake `information_schema.functions` returns type-only signatures (e.g. `(VARCHAR)`) but dbt parameters include names and DEFAULT clauses (e.g. `target_timezone STRING DEFAULT 'Pacific/Auckland'`). Added types-only fallback comparison that strips parameter names and DEFAULT clauses before matching. This prevents UDTFs/functions with DEFAULT parameters from being incorrectly dropped as orphans.
+- Fixed `has_matching_nodes` macro: multi-line parameters (from YAML block scalars or SQL config strings with newlines/tabs) now correctly normalised -- newlines and tabs are replaced with spaces then collapsed, so signature comparison succeeds regardless of whitespace formatting in the parameter definition.
+- Fixed `clean_functions` macro: fallback argument extraction failed on type-only Snowflake signatures because `argument.split(' ')[1]` is out of bounds when the argument is a single type word like `varchar`. Now correctly handles both `name type` and type-only formats, with whitespace-safe splitting.
+
+### Changed
+- Bumped version from 1.0.0 to 1.0.1
+
 ## v1.0.0 - 2026-05-04 - Major Release
 
 ### Breaking Changes

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_dataengineers_utils'
-version: '1.0.0'
+version: '1.0.1'
 config-version: 2
 
 require-dbt-version: [">=1.9.4", "<3.0.0"]

--- a/integration_tests/macros/test_has_matching_nodes.sql
+++ b/integration_tests/macros/test_has_matching_nodes.sql
@@ -69,7 +69,47 @@
         }
     } %}
 
-    {% set all_nodes = [node_simple, node_meta_params, node_override, node_no_params, node_string_type, node_newline_params] %}
+    {# 7. Function with DEFAULT clause in parameters (UDTF pattern) #}
+    {% set node_default_param = {
+        "schema": "m3",
+        "name": "udtf_get_all_active_bank_accounts",
+        "config": {
+            "meta": {
+                "parameters": "target_timezone STRING DEFAULT 'Pacific/Auckland'"
+            }
+        }
+    } %}
+
+    {# 8. Function with multiple params including DEFAULT clauses #}
+    {% set node_multi_default = {
+        "schema": "analytics",
+        "name": "my_multi_default_func",
+        "config": {
+            "parameters": "p_start date, p_timezone string DEFAULT 'UTC', p_limit number DEFAULT 100"
+        }
+    } %}
+
+    {# 9. Function with multi-line parameters (YAML block scalar style) and DEFAULT, in config.meta #}
+    {% set node_multiline_default = {
+        "schema": "m3",
+        "name": "udtf_multiline_params",
+        "config": {
+            "meta": {
+                "parameters": "p_company  NUMBER,\n  p_timezone  STRING  DEFAULT 'Pacific/Auckland',\n  p_active  BOOLEAN  DEFAULT TRUE"
+            }
+        }
+    } %}
+
+    {# 10. Function with multi-line params directly in config (not under meta) #}
+    {% set node_direct_multiline = {
+        "schema": "analytics",
+        "name": "my_direct_multiline_func",
+        "config": {
+            "parameters": "p_id  varchar,\n\tp_name\tvarchar"
+        }
+    } %}
+
+    {% set all_nodes = [node_simple, node_meta_params, node_override, node_no_params, node_string_type, node_newline_params, node_default_param, node_multi_default, node_multiline_default, node_direct_multiline] %}
 
     {# ── Test 1: Match by name with direct config.parameters ── #}
     {% set result = dbt_dataengineers_utils.has_matching_nodes(
@@ -137,7 +177,7 @@
 
     {# ── Test 9: Newline normalization in parameters ── #}
     {% set result = dbt_dataengineers_utils.has_matching_nodes(
-        all_nodes, "name", "ANALYTICS", "MY_NEWLINE_FUNC", "(p_id varchar,p_name varchar)"
+        all_nodes, "name", "ANALYTICS", "MY_NEWLINE_FUNC", "(p_id varchar, p_name varchar)"
     ) %}
     {% if result != true %}
         {% do failures.append("Test 9 FAILED: newline normalization expected true, got " ~ result) %}
@@ -160,6 +200,62 @@
         {% do failures.append("Test 11 FAILED: empty nodes expected false, got " ~ result) %}
     {% endif %}
 
+    {# ── Test 12: DEFAULT clause - Snowflake type-only signature matches dbt params with DEFAULT ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "M3", "UDTF_GET_ALL_ACTIVE_BANK_ACCOUNTS", "(VARCHAR)"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 12 FAILED: DEFAULT clause type-only match expected true, got " ~ result) %}
+    {% endif %}
+
+    {# ── Test 13: DEFAULT clause - full signature still matches when Snowflake includes names ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "M3", "UDTF_GET_ALL_ACTIVE_BANK_ACCOUNTS", "(target_timezone varchar default 'pacific/auckland')"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 13 FAILED: DEFAULT clause full signature match expected true, got " ~ result) %}
+    {% endif %}
+
+    {# ── Test 14: Multiple params with DEFAULT - type-only match ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "ANALYTICS", "MY_MULTI_DEFAULT_FUNC", "(DATE, VARCHAR, NUMBER)"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 14 FAILED: multi-param DEFAULT type-only match expected true, got " ~ result) %}
+    {% endif %}
+
+    {# ── Test 15: DEFAULT clause - wrong type should not match ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "M3", "UDTF_GET_ALL_ACTIVE_BANK_ACCOUNTS", "(NUMBER)"
+    ) %}
+    {% if result != false %}
+        {% do failures.append("Test 15 FAILED: DEFAULT clause wrong type expected false, got " ~ result) %}
+    {% endif %}
+
+    {# ── Test 16: Multi-line params with DEFAULT in meta - type-only match ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "M3", "UDTF_MULTILINE_PARAMS", "(NUMBER, VARCHAR, BOOLEAN)"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 16 FAILED: multi-line meta params type-only match expected true, got " ~ result) %}
+    {% endif %}
+
+    {# ── Test 17: Multi-line params with tabs in direct config - type-only match ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "ANALYTICS", "MY_DIRECT_MULTILINE_FUNC", "(VARCHAR, VARCHAR)"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 17 FAILED: multi-line tab params type-only match expected true, got " ~ result) %}
+    {% endif %}
+
+    {# ── Test 18: Multi-line params with extra spaces - full signature match ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "ANALYTICS", "MY_DIRECT_MULTILINE_FUNC", "(p_id varchar, p_name varchar)"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 18 FAILED: multi-line full signature match expected true, got " ~ result) %}
+    {% endif %}
+
     {# ── Report results ── #}
     {% if failures | length > 0 %}
         {% for f in failures %}
@@ -167,6 +263,6 @@
         {% endfor %}
         {{ exceptions.raise_compiler_error("has_matching_nodes: " ~ (failures | length) ~ " test(s) failed. See log above.") }}
     {% else %}
-        {% do log("has_matching_nodes: all 11 tests passed", info=True) %}
+        {% do log("has_matching_nodes: all 18 tests passed", info=True) %}
     {% endif %}
 {% endmacro %}

--- a/integration_tests/macros/test_has_matching_nodes.sql
+++ b/integration_tests/macros/test_has_matching_nodes.sql
@@ -109,7 +109,27 @@
         }
     } %}
 
-    {% set all_nodes = [node_simple, node_meta_params, node_override, node_no_params, node_string_type, node_newline_params, node_default_param, node_multi_default, node_multiline_default, node_direct_multiline] %}
+    {# 11. Function with compound types including precision in parentheses #}
+    {% set node_compound_types = {
+        "schema": "analytics",
+        "name": "my_compound_func",
+        "config": {
+            "parameters": "p_amount NUMBER(15, 2), p_name VARCHAR(100) DEFAULT 'test', p_rate NUMBER(4, 2)"
+        }
+    } %}
+
+    {# 12. Function with extreme whitespace (many consecutive spaces/tabs) #}
+    {% set node_extreme_ws = {
+        "schema": "analytics",
+        "name": "my_extreme_ws_func",
+        "config": {
+            "meta": {
+                "parameters": "p_id          varchar,\n\t\t\t  p_name          varchar"
+            }
+        }
+    } %}
+
+    {% set all_nodes = [node_simple, node_meta_params, node_override, node_no_params, node_string_type, node_newline_params, node_default_param, node_multi_default, node_multiline_default, node_direct_multiline, node_compound_types, node_extreme_ws] %}
 
     {# ── Test 1: Match by name with direct config.parameters ── #}
     {% set result = dbt_dataengineers_utils.has_matching_nodes(
@@ -256,6 +276,38 @@
         {% do failures.append("Test 18 FAILED: multi-line full signature match expected true, got " ~ result) %}
     {% endif %}
 
+    {# ── Test 19: Compound types with precision - type-only match ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "ANALYTICS", "MY_COMPOUND_FUNC", "(NUMBER(15, 2), VARCHAR(100), NUMBER(4, 2))"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 19 FAILED: compound types type-only match expected true, got " ~ result) %}
+    {% endif %}
+
+    {# ── Test 20: Compound types - full signature match (no DEFAULT) ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "ANALYTICS", "MY_COMPOUND_FUNC", "(p_amount number(15, 2), p_name varchar(100) default 'test', p_rate number(4, 2))"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 20 FAILED: compound types full signature match expected true, got " ~ result) %}
+    {% endif %}
+
+    {# ── Test 21: Extreme whitespace - type-only match ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "ANALYTICS", "MY_EXTREME_WS_FUNC", "(VARCHAR, VARCHAR)"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 21 FAILED: extreme whitespace type-only match expected true, got " ~ result) %}
+    {% endif %}
+
+    {# ── Test 22: Extreme whitespace - full signature match ── #}
+    {% set result = dbt_dataengineers_utils.has_matching_nodes(
+        all_nodes, "name", "ANALYTICS", "MY_EXTREME_WS_FUNC", "(p_id varchar, p_name varchar)"
+    ) %}
+    {% if result != true %}
+        {% do failures.append("Test 22 FAILED: extreme whitespace full signature match expected true, got " ~ result) %}
+    {% endif %}
+
     {# ── Report results ── #}
     {% if failures | length > 0 %}
         {% for f in failures %}
@@ -263,6 +315,6 @@
         {% endfor %}
         {{ exceptions.raise_compiler_error("has_matching_nodes: " ~ (failures | length) ~ " test(s) failed. See log above.") }}
     {% else %}
-        {% do log("has_matching_nodes: all 18 tests passed", info=True) %}
+        {% do log("has_matching_nodes: all 22 tests passed", info=True) %}
     {% endif %}
 {% endmacro %}

--- a/macros/clean/_helpers.sql
+++ b/macros/clean/_helpers.sql
@@ -1,0 +1,79 @@
+{#
+  Helper macros for clean_functions / has_matching_nodes.
+#}
+
+
+{# ── collapse_whitespace ──
+   Replace all runs of whitespace (spaces, tabs, newlines) with a single space and trim.
+   Python's str.split() with no args splits on any whitespace and discards empties,
+   so joining the result reliably collapses arbitrary whitespace runs. #}
+{% macro collapse_whitespace(value) %}
+    {{ return(value.split() | join(' ')) }}
+{% endmacro %}
+
+
+{# ── split_params ──
+   Split a parameter string by commas, respecting parentheses.
+   e.g. "p_id NUMBER(3, 0), p_name VARCHAR" -> ["p_id NUMBER(3, 0)", "p_name VARCHAR"]
+   Plain comma-split would incorrectly break inside NUMBER(3, 0). #}
+{% macro split_params(params_str) %}
+    {% set result = [] %}
+    {% set ns = namespace(current='', depth=0) %}
+    {% for char in params_str %}
+        {% if char == '(' %}
+            {% set ns.depth = ns.depth + 1 %}
+            {% set ns.current = ns.current ~ char %}
+        {% elif char == ')' %}
+            {% set ns.depth = ns.depth - 1 %}
+            {% set ns.current = ns.current ~ char %}
+        {% elif char == ',' and ns.depth == 0 %}
+            {% do result.append(ns.current | trim) %}
+            {% set ns.current = '' %}
+        {% else %}
+            {% set ns.current = ns.current ~ char %}
+        {% endif %}
+    {% endfor %}
+    {# Append the last parameter #}
+    {% if ns.current | trim | length > 0 %}
+        {% do result.append(ns.current | trim) %}
+    {% endif %}
+    {{ return(result) }}
+{% endmacro %}
+
+
+{# ── extract_param_type ──
+   Given a single parameter string such as:
+     "target_timezone varchar default 'Pacific/Auckland'"
+     "p_amount number(15, 2) default 0"
+     "varchar"                         (type-only, no name)
+     "number(3, 0)"                    (type-only with precision)
+   Return just the type portion, e.g. "varchar", "number(15, 2)", "number(3, 0)".
+
+   Strategy:
+     1. Collapse whitespace so tokens are cleanly separated.
+     2. If only one token -> it IS the type (Snowflake type-only format).
+     3. If two or more -> first token is the param name.
+        Everything from the second token up to (but not including) "default" is the type.
+   This handles multi-word / parenthesised types correctly. #}
+{% macro extract_param_type(param_str) %}
+    {% set cleaned = dbt_dataengineers_utils.collapse_whitespace(param_str) %}
+    {% set parts = cleaned.split(' ') %}
+
+    {% if parts | length == 0 or (parts | length == 1 and parts[0] | length == 0) %}
+        {{ return('') }}
+    {% elif parts | length == 1 %}
+        {# Type-only (no param name) #}
+        {{ return(parts[0]) }}
+    {% else %}
+        {# First token is the param name; collect type tokens until we hit "default" #}
+        {% set type_parts = [] %}
+        {% for token in parts[1:] %}
+            {% if token | lower == 'default' %}
+                {{ return(type_parts | join(' ')) }}
+            {% else %}
+                {% do type_parts.append(token) %}
+            {% endif %}
+        {% endfor %}
+        {{ return(type_parts | join(' ')) }}
+    {% endif %}
+{% endmacro %}

--- a/macros/clean/clean.yml
+++ b/macros/clean/clean.yml
@@ -91,6 +91,8 @@ macros:
       Check if a Snowflake-deployed function/procedure matches a dbt graph node by schema, name, and argument signature.
       Supports matching by node.name or by config.meta.override_name for models that deploy under a different name.
       Resolves parameters from config.meta.parameters (falling back to config.parameters) for signature comparison.
+      Includes a types-only fallback to handle Snowflake information_schema returning type-only signatures (e.g. (VARCHAR))
+      when dbt parameters include names and DEFAULT clauses (e.g. "target_timezone STRING DEFAULT 'Pacific/Auckland'").
     docs:
       show: false
     arguments:

--- a/macros/clean/clean_functions.sql
+++ b/macros/clean/clean_functions.sql
@@ -38,34 +38,24 @@
             {% set result_has_matching_nodes = dbt_dataengineers_utils.has_matching_nodes(nodes, "config.override_name", sql_object_schema,sql_object_name,sql_arguments) %}
             {% if result_has_matching_nodes == false %}
 
-                {% set sql_arguments = sql_arguments  | replace("(", "") | replace(")", "") %}
-                {% set sql_arguments_list = sql_arguments.split(',') %}
+                {# Strip the outer parentheses from the Snowflake argument signature #}
+                {% set sql_arguments = sql_arguments | replace("(", "", 1) %}
+                {% if sql_arguments.endswith(")") %}
+                    {% set sql_arguments = sql_arguments[:-1] %}
+                {% endif %}
+                {% set sql_arguments = sql_arguments | trim %}
+
+                {# Extract type-only tokens using paren-aware split #}
                 {% set new_sql_arguments_list = [] %}
-                
-                {% for argument in sql_arguments_list %}
-                    {# Split by space and filter out empty parts from consecutive whitespace #}
-                    {% set argument_parts = [] %}
-                    {% for p in (argument | trim).split(' ') %}
-                        {% if p | trim | length > 0 %}
-                            {% do argument_parts.append(p | trim) %}
+                {% if sql_arguments | length > 0 %}
+                    {% for param in dbt_dataengineers_utils.split_params(sql_arguments) %}
+                        {% set param_type = dbt_dataengineers_utils.extract_param_type(param) %}
+                        {% if param_type | length > 0 %}
+                            {% do new_sql_arguments_list.append(param_type) %}
                         {% endif %}
                     {% endfor %}
-                    {% if argument_parts | length >= 2 %}
-                        {# Format: "name type" - take the type (second word) #}
-                        {% do new_sql_arguments_list.append(argument_parts[1]) %}
-                    {% elif argument_parts | length == 1 and argument_parts[0] | length > 0 %}
-                        {# Format: type-only (Snowflake information_schema style) #}
-                        {% do new_sql_arguments_list.append(argument_parts[0]) %}
-                    {% endif %}
-                {% endfor %}
-                {% for argument in new_sql_arguments_list %}
-                    {%- if not loop.first %}
-                        {% set ns.sql_arguments = ns.sql_arguments ~ "," %}
-                    {% else %}
-                        {% set ns.sql_arguments = "" %}
-                    {% endif -%}
-                    {% set ns.sql_arguments = ns.sql_arguments ~ argument %}
-                {% endfor %}
+                {% endif %}
+                {% set ns.sql_arguments = new_sql_arguments_list | join(",") %}
 
                 {% set sql_signature = (sql_object_schema ~ "." ~ sql_object_name ~ "(" ~ ns.sql_arguments ~ ")") | lower %}
 

--- a/macros/clean/clean_functions.sql
+++ b/macros/clean/clean_functions.sql
@@ -43,8 +43,20 @@
                 {% set new_sql_arguments_list = [] %}
                 
                 {% for argument in sql_arguments_list %}
-                    {% set argument_parts = (argument | trim).split(' ') %}
-                    {% do new_sql_arguments_list.append(argument_parts[1]) %}
+                    {# Split by space and filter out empty parts from consecutive whitespace #}
+                    {% set argument_parts = [] %}
+                    {% for p in (argument | trim).split(' ') %}
+                        {% if p | trim | length > 0 %}
+                            {% do argument_parts.append(p | trim) %}
+                        {% endif %}
+                    {% endfor %}
+                    {% if argument_parts | length >= 2 %}
+                        {# Format: "name type" - take the type (second word) #}
+                        {% do new_sql_arguments_list.append(argument_parts[1]) %}
+                    {% elif argument_parts | length == 1 and argument_parts[0] | length > 0 %}
+                        {# Format: type-only (Snowflake information_schema style) #}
+                        {% do new_sql_arguments_list.append(argument_parts[0]) %}
+                    {% endif %}
                 {% endfor %}
                 {% for argument in new_sql_arguments_list %}
                     {%- if not loop.first %}

--- a/macros/clean/has_matching_nodes.sql
+++ b/macros/clean/has_matching_nodes.sql
@@ -13,7 +13,9 @@
             {% if node_name | lower == sql_object_name | lower %}
                 {# Resolve parameters: try config.meta.parameters, then config.parameters, then '' #}
                 {% set raw_params = node.config.get("meta", {}).get("parameters", node.config.get("parameters", "")) %}
-                {% set dbt_arguments = (raw_params | default("", true)) | lower | replace("string", "varchar") | replace('\n', '') | replace('\r', '') %}
+                {% set dbt_arguments = (raw_params | default("", true)) | lower | replace("string", "varchar") | replace('\n', ' ') | replace('\r', '') | replace('\t', ' ') %}
+                {# Collapse consecutive spaces left over from newline/tab replacement #}
+                {% set dbt_arguments = dbt_arguments | replace('     ', ' ') | replace('    ', ' ') | replace('   ', ' ') | replace('  ', ' ') | trim %}
 
                 {% if name_property == "config.override_name" %}
                     {% set dbt_signature = (node.schema ~ "." ~ node_name ~ "(" ~ dbt_arguments ~ ")") | lower %}
@@ -23,6 +25,43 @@
 
                 {% set sql_signature = (sql_object_schema ~ "." ~ sql_object_name ~ sql_arguments) | lower %}
                 {% if sql_signature == dbt_signature %}
+                    {{ return(true) }}
+                {% endif %}
+
+                {# ── Fallback: compare types-only signatures ──
+                   Snowflake information_schema returns type-only signatures e.g. (VARCHAR)
+                   while dbt parameters may include names and DEFAULT clauses e.g.
+                   "target_timezone VARCHAR DEFAULT 'Pacific/Auckland'".
+                   Parameters may also span multiple lines in YAML/SQL config.
+                   Extract just the types from the dbt side and compare again. #}
+                {% set dbt_types = [] %}
+                {% set clean_dbt_args = dbt_arguments | replace("(", "") | replace(")", "") | trim %}
+                {% if clean_dbt_args | length > 0 %}
+                    {# Split parameters by comma, then extract the type (second word) from each #}
+                    {% for param in clean_dbt_args.split(',') %}
+                        {# Split by space and filter out empty parts from consecutive whitespace #}
+                        {% set parts = [] %}
+                        {% for p in (param | trim).split(' ') %}
+                            {% if p | trim | length > 0 %}
+                                {% do parts.append(p | trim) %}
+                            {% endif %}
+                        {% endfor %}
+                        {% if parts | length >= 2 %}
+                            {% do dbt_types.append(parts[1]) %}
+                        {% elif parts | length == 1 and parts[0] | length > 0 %}
+                            {# Parameter is already type-only (no name prefix) #}
+                            {% do dbt_types.append(parts[0]) %}
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+
+                {% if name_property == "config.override_name" %}
+                    {% set dbt_types_signature = (node.schema ~ "." ~ node_name ~ "(" ~ dbt_types | join(", ") ~ ")") | lower %}
+                {% else %}
+                    {% set dbt_types_signature = (node.schema ~ "." ~ node.name ~ "(" ~ dbt_types | join(", ") ~ ")") | lower %}
+                {% endif %}
+
+                {% if sql_signature == dbt_types_signature %}
                     {{ return(true) }}
                 {% endif %}
             {% endif %}

--- a/macros/clean/has_matching_nodes.sql
+++ b/macros/clean/has_matching_nodes.sql
@@ -13,9 +13,9 @@
             {% if node_name | lower == sql_object_name | lower %}
                 {# Resolve parameters: try config.meta.parameters, then config.parameters, then '' #}
                 {% set raw_params = node.config.get("meta", {}).get("parameters", node.config.get("parameters", "")) %}
-                {% set dbt_arguments = (raw_params | default("", true)) | lower | replace("string", "varchar") | replace('\n', ' ') | replace('\r', '') | replace('\t', ' ') %}
-                {# Collapse consecutive spaces left over from newline/tab replacement #}
-                {% set dbt_arguments = dbt_arguments | replace('     ', ' ') | replace('    ', ' ') | replace('   ', ' ') | replace('  ', ' ') | trim %}
+                {% set dbt_arguments = dbt_dataengineers_utils.collapse_whitespace(
+                    (raw_params | default("", true)) | lower | replace("string", "varchar")
+                ) %}
 
                 {% if name_property == "config.override_name" %}
                     {% set dbt_signature = (node.schema ~ "." ~ node_name ~ "(" ~ dbt_arguments ~ ")") | lower %}
@@ -32,25 +32,15 @@
                    Snowflake information_schema returns type-only signatures e.g. (VARCHAR)
                    while dbt parameters may include names and DEFAULT clauses e.g.
                    "target_timezone VARCHAR DEFAULT 'Pacific/Auckland'".
-                   Parameters may also span multiple lines in YAML/SQL config.
+                   Parameters may also contain parenthesised precision e.g. NUMBER(3, 0).
                    Extract just the types from the dbt side and compare again. #}
                 {% set dbt_types = [] %}
-                {% set clean_dbt_args = dbt_arguments | replace("(", "") | replace(")", "") | trim %}
+                {% set clean_dbt_args = dbt_arguments | trim %}
                 {% if clean_dbt_args | length > 0 %}
-                    {# Split parameters by comma, then extract the type (second word) from each #}
-                    {% for param in clean_dbt_args.split(',') %}
-                        {# Split by space and filter out empty parts from consecutive whitespace #}
-                        {% set parts = [] %}
-                        {% for p in (param | trim).split(' ') %}
-                            {% if p | trim | length > 0 %}
-                                {% do parts.append(p | trim) %}
-                            {% endif %}
-                        {% endfor %}
-                        {% if parts | length >= 2 %}
-                            {% do dbt_types.append(parts[1]) %}
-                        {% elif parts | length == 1 and parts[0] | length > 0 %}
-                            {# Parameter is already type-only (no name prefix) #}
-                            {% do dbt_types.append(parts[0]) %}
+                    {% for param in dbt_dataengineers_utils.split_params(clean_dbt_args) %}
+                        {% set param_type = dbt_dataengineers_utils.extract_param_type(param) %}
+                        {% if param_type | length > 0 %}
+                            {% do dbt_types.append(param_type) %}
                         {% endif %}
                     {% endfor %}
                 {% endif %}

--- a/macros/modelling/modelling.yml
+++ b/macros/modelling/modelling.yml
@@ -58,7 +58,7 @@ macros:
       show: true
     arguments:
       - name: field_list
-        type: Array
+        type: list[string]
         description: The list of fields to be concatenated.
 
   - name: generate_surrogate_key
@@ -70,7 +70,7 @@ macros:
       show: true
     arguments:
       - name: field_list
-        type: Array
+        type: list[string]
         description: List of column expressions to include in the surrogate key hash.
 
   - name: unknown_member


### PR DESCRIPTION
…hangelog and version to 1.0.1

## Pull Request Purpose

- [x] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `main` branch
- [ ] a breaking change — please ensure the base branch is the latest `main` branch

## Description
- Fixed `has_matching_nodes` macro: Snowflake `information_schema.functions` returns type-only signatures (e.g. `(VARCHAR)`) but dbt parameters include names and DEFAULT clauses (e.g. `target_timezone STRING DEFAULT 'Pacific/Auckland'`). Added types-only fallback comparison that strips parameter names and DEFAULT clauses before matching. This prevents UDTFs/functions with DEFAULT parameters from being incorrectly dropped as orphans.
- Fixed `has_matching_nodes` macro: multi-line parameters (from YAML block scalars or SQL config strings with newlines/tabs) now correctly normalised -- newlines and tabs are replaced with spaces then collapsed, so signature comparison succeeds regardless of whitespace formatting in the parameter definition.
- Fixed `clean_functions` macro: fallback argument extraction failed on type-only Snowflake signatures because `argument.split(' ')[1]` is out of bounds when the argument is a single type word like `varchar`. Now correctly handles both `name type` and type-only formats, with whitespace-safe splitting.

## Notes for reviewer
<!---
Any additional notes for the reviewer of the Pull Request
--->

## Checklist

- [ ] I have verified that these changes work locally via my sandbox
- [ ] Added tests & descriptions to my macros (and models if applicable)
- [ ] Pushed code into test
- [ ] Updated the README.md (if applicable)
- [ ] I have added an entry to CHANGELOG.md

## Summary by Sourcery

Fix function/procedure signature matching against Snowflake information_schema and update project metadata for a patch release.

Bug Fixes:
- Ensure has_matching_nodes correctly matches functions when Snowflake exposes type-only signatures and dbt defines parameters with names, defaults, or varying whitespace, preventing valid functions/UDTFs from being treated as orphans.
- Handle type-only argument formats from Snowflake in clean_functions so argument extraction no longer fails when parameter definitions omit names.

Enhancements:
- Normalize and collapse whitespace in macro parameter handling to support multi-line and tabbed parameter definitions consistently.
- Clarify has_matching_nodes macro documentation to describe the types-only fallback behavior.

Build:
- Bump dbt_dataengineers_utils package version from 1.0.0 to 1.0.1.

Documentation:
- Add changelog entry for v1.0.1 describing function signature matching fixes.
- Adjust modelling macro argument type annotations from Array to list[string] for clearer typing.

Tests:
- Extend has_matching_nodes integration tests to cover DEFAULT clauses, multi-parameter signatures, and multi-line/tabbed parameter definitions.