### PR TITLE
Fix clean macro dropping UDFs with DEFAULT parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Data Engineers Snowflake DataOps Utils Project Changelog
 This file contains the changelog for the Data Engineers Snowflake DataOps Utils project, detailing updates, fixes, and enhancements made to the project over time.
 
+## v1.0.2 - 2026-05-12 - Clean Functions Signature Fallback Fix
+
+### Fixed
+- Fixed `has_matching_nodes` macro: the types-only fallback comparison was only extracting types from the dbt side while comparing against the original Snowflake signature which still contained parameter names. This caused UDFs with DEFAULT parameters (e.g. `target_timezone STRING DEFAULT 'Pacific/Auckland'`) to be incorrectly dropped, because the Snowflake signature `(TARGET_TIMEZONE VARCHAR)` includes parameter names that didn't match the dbt types-only signature `(varchar)`. The fallback now extracts types from both sides before comparing.
+
+### Changed
+- Bumped version from 1.0.1 to 1.0.2
+
 ## v1.0.1 - 2026-05-10 - Function Signature Matching Fix
 
 ### Fixed

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_dataengineers_utils'
-version: '1.0.1'
+version: '1.0.2'
 config-version: 2
 
 require-dbt-version: [">=1.9.4", "<3.0.0"]

--- a/macros/clean/_helpers.sql
+++ b/macros/clean/_helpers.sql
@@ -65,15 +65,29 @@
         {# Type-only (no param name) #}
         {{ return(parts[0]) }}
     {% else %}
-        {# First token is the param name; collect type tokens until we hit "default" #}
-        {% set type_parts = [] %}
-        {% for token in parts[1:] %}
-            {% if token | lower == 'default' %}
-                {{ return(type_parts | join(' ')) }}
-            {% else %}
-                {% do type_parts.append(token) %}
-            {% endif %}
-        {% endfor %}
-        {{ return(type_parts | join(' ')) }}
+        {# If the first token contains '(' it is a type with precision (e.g. "number(15, 2)")
+           not a param name, so reassemble all tokens as the type. #}
+        {% if '(' in parts[0] %}
+            {% set type_parts = [] %}
+            {% for token in parts %}
+                {% if token | lower == 'default' %}
+                    {{ return(type_parts | join(' ')) }}
+                {% else %}
+                    {% do type_parts.append(token) %}
+                {% endif %}
+            {% endfor %}
+            {{ return(type_parts | join(' ')) }}
+        {% else %}
+            {# First token is the param name; collect type tokens until we hit "default" #}
+            {% set type_parts = [] %}
+            {% for token in parts[1:] %}
+                {% if token | lower == 'default' %}
+                    {{ return(type_parts | join(' ')) }}
+                {% else %}
+                    {% do type_parts.append(token) %}
+                {% endif %}
+            {% endfor %}
+            {{ return(type_parts | join(' ')) }}
+        {% endif %}
     {% endif %}
 {% endmacro %}

--- a/macros/clean/has_matching_nodes.sql
+++ b/macros/clean/has_matching_nodes.sql
@@ -29,11 +29,11 @@
                 {% endif %}
 
                 {# ── Fallback: compare types-only signatures ──
-                   Snowflake information_schema returns type-only signatures e.g. (VARCHAR)
-                   while dbt parameters may include names and DEFAULT clauses e.g.
-                   "target_timezone VARCHAR DEFAULT 'Pacific/Auckland'".
+                   Snowflake information_schema may return signatures with param names
+                   e.g. (TARGET_TIMEZONE VARCHAR) while dbt parameters include names and
+                   DEFAULT clauses e.g. "target_timezone VARCHAR DEFAULT 'Pacific/Auckland'".
                    Parameters may also contain parenthesised precision e.g. NUMBER(3, 0).
-                   Extract just the types from the dbt side and compare again. #}
+                   Extract just the types from BOTH sides and compare again. #}
                 {% set dbt_types = [] %}
                 {% set clean_dbt_args = dbt_arguments | trim %}
                 {% if clean_dbt_args | length > 0 %}
@@ -45,13 +45,31 @@
                     {% endfor %}
                 {% endif %}
 
-                {% if name_property == "config.override_name" %}
-                    {% set dbt_types_signature = (node.schema ~ "." ~ node_name ~ "(" ~ dbt_types | join(", ") ~ ")") | lower %}
-                {% else %}
-                    {% set dbt_types_signature = (node.schema ~ "." ~ node.name ~ "(" ~ dbt_types | join(", ") ~ ")") | lower %}
+                {# Also extract types-only from the Snowflake side (which may include param names) #}
+                {% set sql_types = [] %}
+                {% set clean_sql_args = sql_arguments | replace("(", "", 1) %}
+                {% if clean_sql_args.endswith(")") %}
+                    {% set clean_sql_args = clean_sql_args[:-1] %}
+                {% endif %}
+                {% set clean_sql_args = clean_sql_args | trim %}
+                {% if clean_sql_args | length > 0 %}
+                    {% for param in dbt_dataengineers_utils.split_params(clean_sql_args) %}
+                        {% set param_type = dbt_dataengineers_utils.extract_param_type(param) %}
+                        {% if param_type | length > 0 %}
+                            {% do sql_types.append(param_type) %}
+                        {% endif %}
+                    {% endfor %}
                 {% endif %}
 
-                {% if sql_signature == dbt_types_signature %}
+                {% if name_property == "config.override_name" %}
+                    {% set dbt_types_signature = (node.schema ~ "." ~ node_name ~ "(" ~ dbt_types | join(", ") ~ ")") | lower %}
+                    {% set sql_types_signature = (sql_object_schema ~ "." ~ sql_object_name ~ "(" ~ sql_types | join(", ") ~ ")") | lower %}
+                {% else %}
+                    {% set dbt_types_signature = (node.schema ~ "." ~ node.name ~ "(" ~ dbt_types | join(", ") ~ ")") | lower %}
+                    {% set sql_types_signature = (sql_object_schema ~ "." ~ sql_object_name ~ "(" ~ sql_types | join(", ") ~ ")") | lower %}
+                {% endif %}
+
+                {% if sql_types_signature == dbt_types_signature %}
                     {{ return(true) }}
                 {% endif %}
             {% endif %}


### PR DESCRIPTION
The types-only fallback in has_matching_nodes was extracting types from the dbt side only, while comparing against the original Snowflake signature which still contained parameter names (e.g. TARGET_TIMEZONE VARCHAR). This caused functions with DEFAULT parameters to never match and get dropped as orphans. The fallback now extracts types from both sides before comparing.

Bump version to 1.0.2.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

## Pull Request Purpose

- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `main` branch
- [ ] a breaking change — please ensure the base branch is the latest `main` branch

## Description
<!---
A clear and concise description of what has changed
--->

## Notes for reviewer
<!---
Any additional notes for the reviewer of the Pull Request
--->

## Checklist

- [ ] I have verified that these changes work locally via my sandbox
- [ ] Added tests & descriptions to my macros (and models if applicable)
- [ ] Pushed code into test
- [ ] Updated the README.md (if applicable)
- [ ] I have added an entry to CHANGELOG.md

## Summary by Sourcery

Fix function signature matching in the clean macro and bump the package version.

Bug Fixes:
- Correct types-only fallback in has_matching_nodes to compare extracted parameter types on both dbt and Snowflake sides, preventing UDFs with DEFAULT parameters from being incorrectly treated as orphans.

Documentation:
- Document v1.0.2 release with notes on the has_matching_nodes fallback fix in the changelog.

Chores:
- Bump project version from 1.0.1 to 1.0.2 in dbt_project.yml.