### PR TITLE
Fix unknown_member macro boolean type inference with explicit casts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ integration_tests/target/
 integration_tests/dbt_packages/
 integration_tests/logs/
 integration_tests/profiles.yml
+integration_tests/package-lock.yml
 plans/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Data Engineers Snowflake DataOps Utils Project Changelog
 This file contains the changelog for the Data Engineers Snowflake DataOps Utils project, detailing updates, fixes, and enhancements made to the project over time.
 
+## v1.0.4 - 2026-05-21 - Unknown Member Boolean Cast Fix
+
+### Fixed
+- Fixed `unknown_member` macro: added explicit `::boolean` casts for `is_current`, `is_deleted`, and generic boolean columns to ensure correct type inference in Snowflake when generating unknown member rows.
+
+### Changed
+- Bumped version from 1.0.3 to 1.0.4
+
 ## v1.0.3 - 2026-05-16 - Data Metric Function Cleanup Support
 
 ### Added

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_dataengineers_utils'
-version: '1.0.3'
+version: '1.0.4'
 config-version: 2
 
 require-dbt-version: [">=1.9.4", "<3.0.0"]

--- a/macros/modelling/unknown_member.sql
+++ b/macros/modelling/unknown_member.sql
@@ -26,9 +26,9 @@
             {%- elif column_names[i] == 'effective_to' %}
         to_timestamp_ltz('2999-12-31 23:59:59') as effective_to{{ line_end }}
             {%- elif column_names[i] == 'is_current' %}
-        true as is_current{{ line_end }}
+        true::boolean as is_current{{ line_end }}
             {%- elif column_names[i] == 'is_deleted' %}
-        false as is_deleted{{ line_end }}
+        false::boolean as is_deleted{{ line_end }}
             {%- elif 'finish' in column_names[i] and column_names[i].endswith('_date') and column_types[i]|upper in ['NUMBER', 'INT', 'INTEGER']%}
         29991231 as {{ column_names[i] }}{{ line_end }}
             {%- elif column_names[i].endswith('_date') and column_types[i]|upper in ['NUMBER', 'INT', 'INTEGER']%}
@@ -38,7 +38,7 @@
             {%- elif column_types[i]|upper in ['NUMBER','INT','DECIMAL']%}
         -1 as {{ column_names[i] }}{{ line_end }}
             {%- elif column_types[i]|upper in ['BOOLEAN']%}
-        true as {{ column_names[i] }}{{ line_end }}
+        true::boolean as {{ column_names[i] }}{{ line_end }}
             {%- else %}
         'Unknown' as {{ column_names[i] }}{{ line_end }}
             {%- endif %}


### PR DESCRIPTION
## Summary
- Added explicit `::boolean` casts to `is_current`, `is_deleted`, and generic boolean columns in the `unknown_member` macro to fix Snowflake type inference issues when generating unknown member rows.
- Bumped version from 1.0.3 to 1.0.4 and updated CHANGELOG.

## Test plan
- [ ] Run `dbt compile` to verify the macro generates valid SQL with the `::boolean` casts
- [ ] Run integration tests against a model using `unknown_member` with boolean columns
- [ ] Verify the generated unknown member row has correct BOOLEAN column types in Snowflake

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

## Summary by Sourcery

Ensure unknown_member macro correctly handles boolean columns in Snowflake and bump package version.

Bug Fixes:
- Correct unknown_member macro boolean column defaults by adding explicit BOOLEAN casts to avoid Snowflake type inference issues.

Enhancements:
- Update project version metadata from 1.0.3 to 1.0.4 to reflect the boolean casting fix.

Tests:
- Add integration package lock configuration for testing the local dbt_dataengineers_utils package.