### PR TITLE
Add grant_operate_to_application macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Data Engineers Snowflake DataOps Utils Project Changelog
 This file contains the changelog for the Data Engineers Snowflake DataOps Utils project, detailing updates, fixes, and enhancements made to the project over time.
 
+## v1.0.5 - 2026-06-16 - Grant OPERATE on Tasks to Applications
+
+### Added
+- Added `grant_operate_to_application` macro to grant OPERATE privilege on tasks matching a name prefix to specified application roles. Discovers tasks via `SHOW TASKS IN DATABASE`, reconciles existing grants (revoking from unlisted applications), and ensures database/schema USAGE is also granted.
+
+### Changed
+- Bumped version from 1.0.4 to 1.0.5
+
 ## v1.0.4 - 2026-05-21 - Unknown Member Boolean Cast Fix
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A macro-only [dbt](https://github.com/dbt-labs/dbt) package for Snowflake DataOps. Provides utilities for object lifecycle management, RBAC grant orchestration, dimensional modelling helpers, tagging, shares, and more.
 
-- **Version**: 1.0.3
+- **Version**: 1.0.5
 - **dbt**: `>=1.3.0, <3.0.0`
 - **Dependencies**: None (zero external package dependencies)
 - **dbt Fusion**: Compatible
@@ -110,6 +110,7 @@ The following `vars` can be set in your `dbt_project.yml` or via `--vars` on the
 | `grant_object(object_type, objects, grant_types, grant_roles)` | Reconcile privilege sets on specific objects for roles |
 | `grant_object_application(object_type, objects, grant_types, grant_applications)` | Reconcile privilege sets on specific objects for applications |
 | `grant_usage_to_application(object_type, prefix, grant_applications)` | Grant USAGE on objects matching a prefix to applications |
+| `grant_operate_to_application(prefix, grant_applications)` | Grant OPERATE on tasks matching a prefix to applications |
 | `grant_share_read(view_names, grant_shares, revoke_current_grants)` | Manage secure view exposure to outbound shares |
 | `grant_share_read_specific_schema(schema_name, view_names, grant_shares, revoke_current_grants)` | Grant SELECT on views in a specific schema to shares |
 | `grant_internal_share_read(share_name, exclude_schemas, dry_run)` | Grant SELECT on all tables/views to an internal share |

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_dataengineers_utils'
-version: '1.0.4'
+version: '1.0.5'
 config-version: 2
 
 require-dbt-version: [">=1.9.4", "<3.0.0"]

--- a/macros/grants/grant_operate_to_application.sql
+++ b/macros/grants/grant_operate_to_application.sql
@@ -13,7 +13,7 @@
             "schema_name" as schema_name,
             concat("schema_name", '.', "name") as object_signature
             from $1
-            where startswith(lower("name"), {{ "'" ~ prefix | lower ~ "'" }});
+            where startswith(lower("name"), {{ "'" ~ (prefix | replace("'", "''") | lower) ~ "'" }});
         {% endset %}
         {% set objects = run_query(matching_objects) %}
 
@@ -35,8 +35,6 @@
                             {% else %}
                                 {% do existing_grants.append({ "privilege" : row.privilege, "role" : row.grantee_name, "schema" : object[1], "object" : object[2] }) %}
                             {%endif%}
-                        {% else %}
-                            {% do revoke_statements.append({ "privilege" : row.privilege, "role" : row.grantee_name, "schema" : object[1], "object" : object[2] }) %}
                         {%endif%}
                     {% endif %}
                 {% endfor %}

--- a/macros/grants/grant_operate_to_application.sql
+++ b/macros/grants/grant_operate_to_application.sql
@@ -1,0 +1,79 @@
+{% macro grant_operate_to_application(prefix, grant_applications) %}
+    {% if flags.WHICH in ['run', 'run-operation'] %}
+        {% set revoke_statements = [] %}
+        {% set grant_statements = [] %}
+        {% set grant_schemas = [] %}
+        {% set execute_statements = [] %}
+        {% set grant_types = ["OPERATE"] %}
+        {% set matching_objects %}
+            show tasks in database {{ target.database }}
+            ->>
+            select
+            "name" as object_name,
+            "schema_name" as schema_name,
+            concat("schema_name", '.', "name") as object_signature
+            from $1
+            where startswith(lower("name"), {{ "'" ~ prefix | lower ~ "'" }});
+        {% endset %}
+        {% set objects = run_query(matching_objects) %}
+
+        {% for object in objects %}
+            {% set existing_grants = [] %}
+            {% if object[1] not in grant_schemas %}
+                {% do grant_schemas.append(object[1]) %}
+            {% endif %}
+            {% set query %}
+                show grants on task {{ target.database }}.{{ object[2] }};
+            {% endset %}
+            {% set results = run_query(query) %}
+            {% if execute %}
+                {% for row in results %}
+                    {% if row.privilege not in ["OWNERSHIP"] %}
+                        {% if row.privilege in grant_types %}
+                            {% if row.grantee_name not in grant_applications %}
+                                {% do revoke_statements.append({ "privilege" : row.privilege, "role" : row.grantee_name, "schema" : object[1], "object" : object[2] }) %}
+                            {% else %}
+                                {% do existing_grants.append({ "privilege" : row.privilege, "role" : row.grantee_name, "schema" : object[1], "object" : object[2] }) %}
+                            {%endif%}
+                        {% else %}
+                            {% do revoke_statements.append({ "privilege" : row.privilege, "role" : row.grantee_name, "schema" : object[1], "object" : object[2] }) %}
+                        {%endif%}
+                    {% endif %}
+                {% endfor %}
+
+                {% for application in grant_applications %}
+                    {% set existing_role_grants = [] %}
+                    {% for existing_grant in existing_grants %}
+                        {% if existing_grant.role == application %}
+                            {% do existing_role_grants.append(existing_grant.privilege) %}
+                        {% endif %}
+                    {% endfor %}
+                    {% for privilege in grant_types %}
+                        {% if privilege not in existing_role_grants %}
+                            {% do grant_statements.append({ "privilege" : privilege, "role" : application, "schema" : object[1], "object" : object[2] }) %}
+                        {% endif %}
+                    {% endfor %}
+                {% endfor %}
+            {%endif%}
+        {%endfor%}
+        {% for stm in revoke_statements %}
+            {% do execute_statements.append("revoke " ~ stm.privilege ~ " on task " ~ target.database ~ "." ~ stm.object ~ " from application " ~ stm.role ~ ";") %}
+        {% endfor %}
+        {% for stm in grant_statements %}
+            {% do execute_statements.append("grant " ~ stm.privilege ~ " on task " ~ target.database ~ "." ~ stm.object ~ " to application " ~ stm.role ~ ";") %}
+        {% endfor %}
+
+        {% do dbt_dataengineers_utils.grant_database_usage_to_application(grant_applications, target.database) %}
+        {% do dbt_dataengineers_utils.grant_schema_usage_to_application(grant_applications, target.database, grant_schemas) %}
+        {% if execute_statements | length > 0 %}
+            {% do log("Executing privilege grants and revokes for tasks...", info=True) %}
+            {% for statement in execute_statements %}
+                {% do log(statement, info=True) %}
+                {% set grant = run_query(statement) %}
+            {% endfor %}
+            {% do log("Privilege grants and revokes executed successfully for tasks.", info=True) %}
+        {% else %}
+            {% do log("No privilege grants or revokes to execute for tasks.", info=True) %}
+        {% endif %}
+    {% endif %}
+{% endmacro %}

--- a/macros/grants/grants.yml
+++ b/macros/grants/grants.yml
@@ -157,6 +157,18 @@ macros:
         type: List[string]
         description: List of schemas to grant usage privileges on
 
+  - name: grant_operate_to_application
+    description: This macro grants OPERATE privilege on tasks matching a name prefix to specified application roles. Also grants database and schema USAGE to the applications.
+    docs:
+      show: true
+    arguments:
+      - name: prefix
+        type: string
+        description: Prefix for the task names to apply the permission to
+      - name: grant_applications
+        type: List[string]
+        description: List of application roles to grant OPERATE privilege to
+
   - name: grant_privileges
     description: |
       Grants a bundle of privileges across environments based on target context.


### PR DESCRIPTION
## Summary
- Added new `grant_operate_to_application(prefix, grant_applications)` macro that grants OPERATE privilege on tasks matching a name prefix to specified application roles
- Discovers tasks via `SHOW TASKS IN DATABASE`, reconciles existing grants (revoking from unlisted applications), and ensures database/schema USAGE is also granted
- Follows same pattern as `grant_usage_to_application` but purpose-built for tasks
- Bumped version to 1.0.5

## Test plan
- [x] `dbt compile` passes in integration_tests (25 artifacts compiled)
- [ ] Run against a target with tasks to verify grant/revoke logic
- [ ] Verify macro works with `dbt run-operation grant_operate_to_application --args '{prefix: tsk_my_prefix, grant_applications: [MY_APP]}'`

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

## Summary by Sourcery

Add a macro to manage OPERATE privileges on Snowflake tasks for application roles and bump the package version.

New Features:
- Introduce grant_operate_to_application macro to grant and reconcile OPERATE privileges on tasks matching a name prefix for specified application roles.

Documentation:
- Document the new grant_operate_to_application macro in grants configuration and README.
- Update README version badge to reflect the new release.

Chores:
- Update changelog with v1.0.5 entry describing the new task operate-grant macro and behavior.
- Bump project version from 1.0.4 to 1.0.5 in project configuration.