### PR TITLE
Fix grant macros SQL quoting (v1.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Data Engineers Snowflake DataOps Utils Project Changelog
 This file contains the changelog for the Data Engineers Snowflake DataOps Utils project, detailing updates, fixes, and enhancements made to the project over time.
 
+## v1.0.8 - 2026-06-25 - Grant SQL Quoting Fix
+
+### Fixed
+- Fixed SQL compilation error in grant macros caused by `tojson` Jinja filter producing double-quoted strings (`"ROLE_NAME"`) which Snowflake interprets as identifiers instead of string literals. Replaced with `join("', '")` pattern to produce correct single-quoted SQL strings (`'ROLE_NAME'`). Affected macros: `grant_schema_read`, `grant_schema_object_privileges`, and `_grants_get_schema_object_privs`.
+
+### Changed
+- Bumped version from 1.0.7 to 1.0.8
+
 ## v1.0.7 - 2026-06-25 - Grant Performance Optimization
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A macro-only [dbt](https://github.com/dbt-labs/dbt) package for Snowflake DataOps. Provides utilities for object lifecycle management, RBAC grant orchestration, dimensional modelling helpers, tagging, shares, and more.
 
-- **Version**: 1.0.7
+- **Version**: 1.0.8
 - **dbt**: `>=1.3.0, <3.0.0`
 - **Dependencies**: None (zero external package dependencies)
 - **dbt Fusion**: Compatible

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_dataengineers_utils'
-version: '1.0.7'
+version: '1.0.8'
 config-version: 2
 
 require-dbt-version: [">=1.9.4", "<3.0.0"]

--- a/macros/grants/_helpers.sql
+++ b/macros/grants/_helpers.sql
@@ -132,10 +132,10 @@ These ideas intentionally deferred to keep current refactor incremental.
         from information_schema.object_privileges
         where object_schema = '{{ schema }}'
         {% if priv_filter | length > 0 %}
-          and privilege_type in ({{ priv_filter | map('tojson') | join(', ') }})
+          and privilege_type in ('{{ priv_filter | join("', '") }}')
         {% endif %}
         {% if grantees_upper | length > 0 %}
-          and grantee in ({{ grantees_upper | map('tojson') | join(', ') }})
+          and grantee in ('{{ grantees_upper | join("', '") }}')
         {% endif %}
         {% if object_type is not none %}
           and object_type = '{{ object_type | upper }}'

--- a/macros/grants/grant_schema_object_privileges.sql
+++ b/macros/grants/grant_schema_object_privileges.sql
@@ -80,8 +80,8 @@
         select distinct privilege_type, grantee
         from information_schema.object_privileges
         where object_schema = '{{ schema_name }}'
-          and privilege_type in ({{ permission_list | map('upper') | map('tojson') | join(', ') }})
-          and grantee not in ({{ role_list | map('tojson') | join(', ') }})
+          and privilege_type in ('{{ permission_list | map('upper') | join("', '") }}')
+          and grantee not in ('{{ role_list | join("', '") }}')
           and object_type = '{{ object_type | upper }}'
           and grantor is not null
     {% endset %}

--- a/macros/grants/grant_schema_read.sql
+++ b/macros/grants/grant_schema_read.sql
@@ -77,7 +77,7 @@
                     and table_privileges.table_catalog = tables.table_catalog
                 where tables.table_schema = '{{ schema }}'
                   and table_privileges.privilege_type in ('SELECT','REFERENCES','REBUILD')
-                  and table_privileges.grantee not in ({{ grant_roles | map('tojson') | join(', ') }})
+                  and table_privileges.grantee not in ('{{ grant_roles | join("', '") }}')
                   and granted_to = 'ROLE'
             {% endset %}
             {% set tbl_privs = run_query(revoke_query) %}


### PR DESCRIPTION
## Summary
- Fixed SQL compilation error in grant macros where Jinja's `tojson` filter produced double-quoted strings (`"ROLE_NAME"`) that Snowflake interprets as identifiers instead of string literals
- Replaced `map('tojson') | join(', ')` with the idiomatic `'{{ list | join("', '") }}'` pattern across 3 macro files (5 occurrences) to emit correct single-quoted SQL strings
- Bumped version to 1.0.8, updated CHANGELOG and README

## Test plan
- [ ] Run `dbt run-operation grant_schema_read` against a schema with roles to confirm no `invalid identifier` errors
- [ ] Run `dbt run-operation grant_schema_object_privileges` and verify generated SQL uses single-quoted role names
- [ ] Verify `_grants_get_schema_object_privs` helper produces correct SQL in dry-run mode

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

## Summary by Sourcery

Fix SQL quoting in grant macros to prevent Snowflake from treating role and privilege names as identifiers, and bump the package version to 1.0.8.

Bug Fixes:
- Correct grant macro filters to emit single-quoted SQL string literals for privileges and grantees instead of double-quoted identifiers.

Enhancements:
- Align grant macro Jinja templates with idiomatic list joining patterns for cleaner and more reliable SQL generation.

Build:
- Update dbt project version metadata to 1.0.8.

Documentation:
- Update README and CHANGELOG to document the grant SQL quoting fix and new 1.0.8 version.